### PR TITLE
fixed possible range check error

### DIFF
--- a/Lib/UIRibbonCommands.pas
+++ b/Lib/UIRibbonCommands.pas
@@ -3730,7 +3730,7 @@ begin
         Result := UIInitPropertyFromString(Key, Val.AsString, Value);
 
       VT_UI4:
-        Result := UIInitPropertyFromUInt32(Key, Val.AsInteger, Value);
+        Result := UIInitPropertyFromUInt32(Key, cardinal(Val.AsInteger), Value);
 
       VT_UNKNOWN:
         begin


### PR DESCRIPTION
Second parameter to UIInitPropertyFromUInt32 is a cardinal so .AsInteger must be cast to prevent range check errors. (We experienced this problem in real life.)