### PR TITLE
Fixed code that could generate negative FEnumIndex

### DIFF
--- a/Lib/UIRibbonCommands.pas
+++ b/Lib/UIRibbonCommands.pas
@@ -3940,6 +3940,9 @@ begin
   if ((FEnumIndex + celt) <= FItems.Count) then
   begin
     Inc(FEnumIndex, celt);
+    // Sometimes, `celt` can be -1
+    if FEnumIndex < 0 then
+      FEnumIndex := 0;
     Result := S_OK;
   end
   else

--- a/Lib/UIRibbonCommands.pas
+++ b/Lib/UIRibbonCommands.pas
@@ -3730,7 +3730,7 @@ begin
         Result := UIInitPropertyFromString(Key, Val.AsString, Value);
 
       VT_UI4:
-        Result := UIInitPropertyFromUInt32(Key, cardinal(Val.AsInteger), Value);
+        Result := UIInitPropertyFromUInt32(Key, Val.AsInteger, Value);
 
       VT_UNKNOWN:
         begin


### PR DESCRIPTION
Sometimes (if I remember correctly when a gallery is open and user moves mouse up and down over the gallery drop-down), Windows Ribbon Framework calls this with `celt = -1`. If FEnumIndex is equal to 0 at that moment, it gets set to -1 which causes problems later on.