### PR TITLE
FastMM FullDebugMode workaround

### DIFF
--- a/Lib/UIRibbon.pas
+++ b/Lib/UIRibbon.pas
@@ -1003,7 +1003,11 @@ begin
   if (Result) then
   begin
     ComStream := TStreamAdapter.Create(Stream, soReference);
+  {$IFNDEF FullDebugMode}
     Result := Succeeded(FRibbon.LoadSettingsFromStream(ComStream));
+  {$ELSE}
+    {$MESSAGE WARN 'Cannot save ribbon state in FullDebugMode'}
+  {$ENDIF}
   end;
 end;
 
@@ -1170,7 +1174,11 @@ begin
   if (Result) and fLoaded then
   begin
     ComStream := TStreamAdapter.Create(Stream, soReference);
+  {$IFNDEF FullDebugMode}
     Result := Succeeded(FRibbon.SaveSettingsToStream(ComStream));
+  {$ELSE}
+    {$MESSAGE WARN 'Cannot save ribbon state in FullDebugMode'}
+  {$ENDIF FullDebugMode}
   end;
 end;
 

--- a/Lib/UIRibbonCommands.pas
+++ b/Lib/UIRibbonCommands.pas
@@ -3730,7 +3730,7 @@ begin
         Result := UIInitPropertyFromString(Key, Val.AsString, Value);
 
       VT_UI4:
-        Result := UIInitPropertyFromUInt32(Key, cardinal(Val.AsInteger), Value);
+        Result := UIInitPropertyFromUInt32(Key, Val.AsInteger, Value);
 
       VT_UNKNOWN:
         begin


### PR DESCRIPTION
We are experiencing crashes in FRibbon.LoadSettingsFromStream and FRibbon.SaveSettingsToStream if FastMM's FullDebugMode is enabled. This commit disables those two calls if FullDebugMode is defined.