### PR TITLE
added TUICommand.OnUpdateHint propery

### DIFF
--- a/Lib/UIRibbonActions.pas
+++ b/Lib/UIRibbonActions.pas
@@ -172,13 +172,18 @@ var
 begin
   if IsHintLinked then
   begin
-    I := Pos('|', Value);
-    if (I = 0) then
-      FClient.TooltipTitle := Value
+    if assigned(FClient.OnUpdateHint) then
+      FClient.OnUpdateHint(FClient, Value)
     else
     begin
-      FClient.TooltipTitle := Copy(Value, 1, I - 1);
-      FClient.TooltipDescription := Copy(Value, I + 1, MaxInt);
+      I := Pos('|', Value);
+      if (I = 0) then
+        FClient.TooltipTitle := Value
+      else
+      begin
+        FClient.TooltipTitle := Copy(Value, 1, I - 1);
+        FClient.TooltipDescription := Copy(Value, I + 1, MaxInt);
+      end;
     end;
   end;
 end;

--- a/Lib/UIRibbonCommands.pas
+++ b/Lib/UIRibbonCommands.pas
@@ -139,6 +139,8 @@ type
   TUICommandUpdateImageEvent = procedure (Sender: TObject; const PropKey: TUIPropertyKey;
     out NewValue: TPropVariant; var Handled: boolean) of object;
 
+  TUICommandUpdateHintEvent = procedure (Sender: TObject; const Value: string) of object;
+
   { Abstract base class for Ribbon Commands. }
   TUICommand = class abstract(TComponent, IUICommandHandler)
   {$REGION 'Internal Declarations'}
@@ -165,6 +167,7 @@ type
       vpTooltipDescription, vpLabelDescription, vpMinValue, vpMaxValue,
       vpIncrement, vpDecimalPlaces, vpRepresentativeString, vpFormatString);
     FActionLink: TActionLink;
+    FOnUpdateHint: TUICommandUpdateHintEvent;
     FOnUpdateImage: TUICommandUpdateImageEvent;
     procedure SetAlive(const Value: Boolean);
   strict private
@@ -310,6 +313,13 @@ type
     { Can be used to dynamically generate an image for a command.}
     property OnUpdateImage: TUICommandUpdateImageEvent read FOnUpdateImage write
       FOnUpdateImage;
+
+    { Allows you to override automation action.Hint changes.
+      If assigned, event handler should process hint and set up command properties
+      accordingly. If not assigned , internal processing is done in
+      UIRibbonActions.pas/TUICommandActionLink.SetHint. }
+    property OnUpdateHint: TUICommandUpdateHintEvent read FOnUpdateHint write
+      FOnUpdateHint;
 
     (************************************************************************
      * A note about command events


### PR DESCRIPTION
This change allows an application to do custom processing when TAction.Hint changes (for example, when UI is translated) and set command's properties accordingly.