### PR TITLE
Modify link to GitHub and correct link to License file

### DIFF
--- a/License.txt
+++ b/License.txt
@@ -1,5 +1,5 @@
 Windows Ribbon Framework for Delphi.
-Website: https://code.google.com/p/delphi-ribbon-framework/
+Website: https://github.com/turbopack/ribbonframework/
 
 Copyright (C) 2015 by Erik van Bilsen, Joachim Marder
 All rights reserved.

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -55,4 +55,4 @@ This framework was originally developed by [Eric Bilsen](http://www.bilsen.com/w
 Our issue tracker is intended to file bugs, it is not a support forum. Please use e.g. [stackoverflow.com](http://stackoverflow.com/) to get support. When submitting bugs, please include all error messages and a sample project or steps how to replicate the problem with one of the included sample projects.
 
 ## License ##
-[License file](https://raw.githubusercontent.com/TurboPack/RibbonFramework/master/Doc/License.txt)
+[License file](https://raw.githubusercontent.com/TurboPack/RibbonFramework/master/License.txt)


### PR DESCRIPTION
I have modified a link for GitHub instead of Google Code and corrected the link to the License file in ReadMe.md.