### PR TITLE
Change `var` to `out` in interface to unbreak examples

### DIFF
--- a/Lib/UIRibbonApi.pas
+++ b/Lib/UIRibbonApi.pas
@@ -508,7 +508,7 @@ type
 
     // Informs of the current value of a property, and queries for the new one
     function UpdateProperty(CommandId: UInt32; const Key: TUIPropertyKey;
-      CurrentValue: PPropVariant; var NewValue: TPropVariant): HRESULT; stdcall;
+      CurrentValue: PPropVariant; out NewValue: TPropVariant): HRESULT; stdcall;
   end;
 
   // Types of UI commands


### PR DESCRIPTION
Some of the example projects do not compile since they implement a different version of the interface `IUICommandHandler `. This is a breaking change for users of this library.